### PR TITLE
Update Guava to support last version of Selenium

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>14.0</version>
+			<version>16.0</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/main/java/com/nhinds/lastpass/impl/PasswordStoreImpl.java
+++ b/src/main/java/com/nhinds/lastpass/impl/PasswordStoreImpl.java
@@ -71,7 +71,7 @@ public class PasswordStoreImpl implements PasswordStore {
 			if (domainName.isUnderPublicSuffix()) {
 				domainName = domainName.topPrivateDomain();
 			}
-			return domainName.name();
+			return domainName.toString();
 		} catch (final IllegalArgumentException e) {
 			return host;
 		}


### PR DESCRIPTION
Selenium uses Guava v25.0-jre, to keep compatibility with (old) android versions as high as possible, update this project to use Guava v16.0, which is the oldest version that contains the change that makes lastpass-java incompatible with later versions of Selenium.